### PR TITLE
Update devcontainer for Rails 8.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,24 +1,39 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=3.1-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
+# Ruby 3.3.6 for Rails 8.1 development
+FROM ruby:3.3.6-bookworm
 
-# Install Rails
-RUN gem install rails webdrivers 
+# Install development dependencies
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    curl \
+    git \
+    libsqlite3-dev \
+    libvips \
+    nodejs \
+    npm \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Install Rails 8.1
+RUN gem install rails -v '~> 8.1.0'
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
-# The value is a comma-separated list of allowed domains 
-ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
+ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.app.github.dev"
 
-# [Choice] Node.js version: lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
+# Set working directory
+WORKDIR /workspace
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install additional gems.
-# RUN gem install <your-gem-names-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+# Switch to non-root user
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,41 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/ruby-rails-postgres
-// Update the VARIANT arg in docker-compose.yml to pick a Ruby version
 {
-	"name": "Ruby on Rails & Postgres",
+	"name": "Rails 8.1 Development",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": { },
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"ruby.intellisense": "rubyLocate",
+				"ruby.useBundler": true,
+				"ruby.format": "rubocop",
+				"[ruby]": {
+					"editor.defaultFormatter": "Shopify.ruby-lsp",
+					"editor.formatOnSave": true,
+					"editor.tabSize": 2,
+					"editor.insertSpaces": true
+				}
+			},
+			"extensions": [
+				"Shopify.ruby-lsp",
+				"KoichiSasada.vscode-rdbg",
+				"vscode-icons-team.vscode-icons",
+				"GitHub.copilot",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"rebornix.Ruby",
-		"vscode-icons-team.vscode-icons",
-		"GitHub.copilot-nightly",
-		"TabNine.tabnine-vscode"
-	],
+	"forwardPorts": [3000],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// This can be used to network with other containers or the host.
-	// "forwardPorts": [3000, 5432],
+	"postCreateCommand": "bundle install && bin/rails db:prepare",
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "bundle install && rake db:setup",
-
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
+
 	"features": {
-		"github-cli": "latest"
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"version": "latest"
+		}
 	}
 }


### PR DESCRIPTION
Updates the devcontainer configuration to support Rails 8.1 development.

## Changes
- Update to Ruby 3.3.6 (Rails 8.1 requirement)
- Modernize Dockerfile with bookworm base image
- Install required dependencies (libvips, sqlite3, etc.)
- Update VSCode extensions to use ruby-lsp instead of deprecated extensions
- Add proper formatting and debugging support
- Configure postCreateCommand for automatic setup
- Update RAILS_DEVELOPMENT_HOSTS for GitHub Codespaces

## Testing
- Devcontainer should build successfully
- Rails app should be accessible on port 3000
- Ruby LSP should provide proper IntelliSense

Closes #