### PR TITLE
chore(deps): update bootsnap to 1.24.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.4)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
Carries the exact Bootsnap update from Dependabot PR #343 onto the audit-remediated main branch while retaining newer audited transitive dependencies. GitHub Actions must pass before merge.